### PR TITLE
Add nvim_test-proc_macro

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Run miri test
         uses: actions-rs/cargo@v1
+        env:
+          RUST_BACKTRACE: 1
         with:
           toolchain: nightly
           command: miri

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["neovim_sys", "nvim_api", "overkill_nvim"]
+members = ["neovim_sys", "nvim_api", "overkill_nvim", "nvim_api_test"]

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ test-miri:
   cargo +nightly miri test --workspace
 
 test-lua:
-  cargo build --features lua_test --package nvim-api --package overkill-nvim
+  cargo build --features lua_test --package nvim_api --package overkill_nvim
   nvim --headless -n -c "PlenaryBustedDirectory tests/plenary {minimal_init = 'tests/minimal_init.vim'}"
 
 fix-clippies:

--- a/nvim_api/Cargo.toml
+++ b/nvim_api/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 approx = { version = "0.5", optional = true }
 neovim_sys = { path = "../neovim_sys" }
+nvim_api_test = { path = "../nvim_api_test" }
 thiserror = "1.0"
 
 [features]

--- a/nvim_api_test/Cargo.toml
+++ b/nvim_api_test/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
-name = "nvim_test-proc_macro"
+name = "nvim_api_test"
 version = "0.1.0"
 edition = "2021"
+
+[lib]
+proc-macro = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+quote = { version = "1.0" }
+syn = { version = "1.0", features = ["full"] }

--- a/nvim_api_test/src/lib.rs
+++ b/nvim_api_test/src/lib.rs
@@ -1,0 +1,53 @@
+#![deny(unused_extern_crates)]
+#![warn(
+    clippy::all,
+    clippy::nursery,
+    clippy::pedantic,
+    future_incompatible,
+    missing_copy_implementations,
+    nonstandard_style,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts,
+    unreachable_pub,
+    unused_qualifications
+)]
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn nvim_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+    let fn_name = &input.sig.ident;
+    let block = input.block;
+
+    let test_code = quote::quote! {
+        #[allow(box_pointers)]
+        #[no_mangle]
+        pub extern "C" fn #fn_name() -> bool {
+            std::panic::set_hook(Box::new(|panic_info| {
+                match (panic_info.payload().downcast_ref::<String>(), panic_info.location()) {
+                    (Some(payload), Some(location)) => {
+                        eprintln!("FAIL! [{}:{}]\n{}", location.file(), location.line(), payload)
+                    }
+                    (Some(payload), None) => {
+                        eprintln!("FAIL! [unknown location]\n{}", payload)
+                    }
+                    (None, Some(location)) => {
+                        eprintln!("FAIL! [{}:{}]", location.file(), location.line())
+                    }
+                    (None, None) => {
+                        eprintln!("FAIL! [unknown location")
+                    }
+                }
+
+            }));
+
+            let result = std::panic::catch_unwind(|| #block);
+
+            result.is_ok()
+        }
+    };
+
+    test_code.into()
+}

--- a/nvim_test-proc_macro/src/lib.rs
+++ b/nvim_test-proc_macro/src/lib.rs
@@ -1,8 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}

--- a/overkill_nvim/Cargo.toml
+++ b/overkill_nvim/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 nvim_api = { path = "../nvim_api/" }
+nvim_api_test = { path = "../nvim_api_test" }
 thiserror = "1.0"
 
 [features]

--- a/overkill_nvim/src/lua_test.rs
+++ b/overkill_nvim/src/lua_test.rs
@@ -8,52 +8,20 @@ use crate::{
         ShortMessItem, StringOption,
     },
 };
+use nvim_api_test::nvim_test;
 
-fn panic_hook(panic_info: &std::panic::PanicInfo<'_>) {
-    if let Some(location) = panic_info.location() {
-        eprintln!(
-            "panic occurred in file '{}' at line {}",
-            location.file(),
-            location.line()
-        );
-    } else {
-        eprintln!("panic occurred but can't get location information...");
-    }
-
-    if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
-        eprintln!("FAIL: {}", s);
-        return;
-    }
-
-    if let Some(s) = panic_info.payload().downcast_ref::<String>() {
-        eprintln!("FAIL: {}", s);
-    }
-}
-
-macro_rules! test {
-    ($name:ident, $body:tt) => {
-        #[allow(box_pointers)]
-        #[no_mangle]
-        pub extern "C" fn $name() -> bool {
-            std::panic::set_hook(Box::new(panic_hook));
-
-            let result = std::panic::catch_unwind(|| $body);
-
-            result.is_ok()
-        }
-    };
-}
-
-test!(test_overkill_set_global_string_option, {
+#[nvim_test]
+fn test_overkill_set_global_string_option() {
     let new_value = CompleteOptSettings::default().no_select().no_insert();
 
     CompleteOpt::set_global(new_value).unwrap();
 
     let value = CompleteOpt::get_global().unwrap();
     assert_eq!(value, new_value);
-});
+}
 
-test!(test_overkill_set_global_nullable_string_option, {
+#[nvim_test]
+fn test_overkill_set_global_nullable_string_option() {
     // The default is "", so test we get a None.
     assert!(PasteToggle::get_global().unwrap().is_none());
 
@@ -63,61 +31,55 @@ test!(test_overkill_set_global_nullable_string_option, {
     let value = PasteToggle::get_global().unwrap().unwrap();
 
     assert_eq!(value, new_value);
-});
+}
 
-test!(
-    test_overkill_set_global_nullable_string_char_flags_option,
-    {
-        // First test setting to "".
-        let value = ShortMess::get_global().unwrap();
-        assert!(value.is_some(), "expected Some(_), got None");
+#[nvim_test]
+fn test_overkill_set_global_nullable_string_char_flags_option() {
+    // First test setting to "".
+    let value = ShortMess::get_global().unwrap();
+    assert!(value.is_some(), "expected Some(_), got None");
 
-        let new_value = CharFlags::new(vec![ShortMessItem::AbbreviateFile]);
+    let new_value = CharFlags::new(vec![ShortMessItem::AbbreviateFile]);
 
-        ShortMess::set_global(Some(new_value.clone())).unwrap();
-        let value = ShortMess::get_global().unwrap().unwrap();
+    ShortMess::set_global(Some(new_value.clone())).unwrap();
+    let value = ShortMess::get_global().unwrap().unwrap();
 
-        assert_eq!(new_value, value);
-    }
-);
+    assert_eq!(new_value, value);
+}
 
-test!(
-    test_overkill_set_add_assign_global_nullable_string_char_flags_option,
-    {
-        let new_value = ShortMessItem::AbbreviateModified;
+#[nvim_test]
+fn test_overkill_set_add_assign_global_nullable_string_char_flags_option() {
+    let new_value = ShortMessItem::AbbreviateModified;
 
-        let expected = ShortMess::get_global()
-            .unwrap()
-            .map(|mut current| {
-                current.push(new_value);
-                current
-            })
-            .unwrap();
+    let expected = ShortMess::get_global()
+        .unwrap()
+        .map(|mut current| {
+            current.push(new_value);
+            current
+        })
+        .unwrap();
 
-        ShortMess::add_assign_global(new_value).unwrap();
+    ShortMess::add_assign_global(new_value).unwrap();
 
-        let value = ShortMess::get_global().unwrap().unwrap();
+    let value = ShortMess::get_global().unwrap().unwrap();
 
-        assert_eq!(expected, value);
-    }
-);
+    assert_eq!(expected, value);
+}
 
-test!(
-    test_overkill_set_sub_assign_global_nullable_string_char_flags_option,
-    {
-        let to_remove = ShortMessItem::AbbreviateFile;
+#[nvim_test]
+fn test_overkill_set_sub_assign_global_nullable_string_char_flags_option() {
+    let to_remove = ShortMessItem::AbbreviateFile;
 
-        let before = ShortMess::get_global().unwrap().unwrap();
-        let before_len = before.len();
+    let before = ShortMess::get_global().unwrap().unwrap();
+    let before_len = before.len();
 
-        ShortMess::sub_assign_global(&to_remove).unwrap();
+    ShortMess::sub_assign_global(&to_remove).unwrap();
 
-        let value = ShortMess::get_global().unwrap().unwrap();
-        assert_eq!(value.len(), before_len - 1, "value: {:?}", value);
+    let value = ShortMess::get_global().unwrap().unwrap();
+    assert_eq!(value.len(), before_len - 1, "value: {:?}", value);
 
-        let mut expected = before;
-        expected.remove(&to_remove);
+    let mut expected = before;
+    expected.remove(&to_remove);
 
-        assert_eq!(expected, value);
-    }
-);
+    assert_eq!(expected, value);
+}


### PR DESCRIPTION
Adds a new proc-macro crate for writing tests. 

At this point, I'm running all tests via [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) inside headless neovim, where writing a test entails:

1. Write a test function with `#[no_mangle] extern "C"` that returns a `bool`.
2. Update the related .lua test file to wrap the exported function.
3. Call the function using plenary's `test_harness`; if the exported function from 1 above returns false, the test failed.

Since any panics (assertions, etc) don't lend themselves to causing plenary tests to fail, each test function would have to simulate assertions by checking values and returning `false` if the expectation wasn't met. This made for some really verbose and unidiomatic Rust code. The new `nvim_test`, while also not quite ideal, is a big improvement. Tests can now use `assert`s and `unwrap`s, just like in idiomatic Rust, but that alone requires much less code than before. This also gives me some ideas about how it could be possible to ditch the reliance on lua-jit's ffi and plenary's test_harness for all this. But that's for another time.